### PR TITLE
bug fix: restclient.request throwing "Cannot read property 'message' of null"

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -246,7 +246,7 @@ export class RestRequest {
 
     const data = await response.body();
     if (!response.ok) {
-      if (typeof(data) === 'object') {
+      if (typeof(data) === 'object' && data !== null) {
         if (
           (this.client.restClient.baseUrl instanceof URL) &&
           (this.client.restClient.baseUrl.host === this.request.url.host)


### PR DESCRIPTION
Due to `typeof null` returning `object`, the condition (`typeof (data) === 'object'`) will be true which results in it trying to read property 'message' of null