### PR TITLE
Use a Bearer token for non-Bot auth types

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -116,6 +116,7 @@ export class Client extends EventSpewer {
   get authTypeText(): string {
     switch (this.authType) {
       case AuthTypes.BOT: return 'Bot';
+      case AuthTypes.USER: return 'Bearer';
     }
     return '';
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -116,9 +116,8 @@ export class Client extends EventSpewer {
   get authTypeText(): string {
     switch (this.authType) {
       case AuthTypes.BOT: return 'Bot';
-      case AuthTypes.USER: return 'Bearer';
     }
-    return '';
+    return 'Bearer';
   }
 
   get isBot(): boolean {


### PR DESCRIPTION
When presenting a token, if this is not a bot type, use a Bearer token.

Test case:
```
import { AuthTypes } from 'detritus-client-rest/lib/constants'
import { Client as Discord } from 'detritus-client-rest'
import qs = require('querystring')
import axios = require('axios')

interface OAuthResponse {
    access_token: string
    expires_in: number
    scope: string
    token_type: string
}

export const getOAuthResponse = async (clientId: string, clientSecret: string) => {
    const body = {
        grant_type: 'client_credentials',
        scope: 'identify connections',
        client_id: clientId,
        client_secret: clientSecret,
    }

    const response = await axios.default.post<OAuthResponse>('https://discord.com/api/oauth2/token', qs.stringify(body), {
        headers: {
            'Content-Type': 'application/x-www-form-urlencoded',
        },
    })
    return response.data
}

export const getMe: any = async (token: string) => {
    const discord = new Discord(token, {
        authType: AuthTypes.USER,
    })

    return await discord.fetchMe()
}

const id = '...'
const secret = '...'

console.log('starting')
getOAuthResponse(id, secret).then((r) => {
    getMe(r.access_token).then((me: any) => {
        console.log(me)
    })
})


```