### PR TITLE
Name is optional for components in emojis

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1178,7 +1178,7 @@ export namespace RequestTypes {
   export interface RawEmojiPartial  {
     animated?: boolean,
     id?: string,
-    name: string,
+    name?: string,
   }
 
   /* Route Types */


### PR DESCRIPTION
Emoji in components with a default emoji can be done with { name: '🎉' } and custom with { id: '4913507123502835123' } but right now detritus requires an emoji name for even custom emojis

This pull request just makes name optional