### PR TITLE
Cannot remove embeds on edit

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3223,7 +3223,7 @@ export class Client extends EventSpewer {
         options.embeds = [];
       }
     }
-    if (options.embeds && options.embeds.length) {
+    if (options.embeds) {
       body.embeds = options.embeds.map((embed) => {
         if ('toJSON' in embed) {
           return embed;
@@ -3531,7 +3531,7 @@ export class Client extends EventSpewer {
         options.embeds = [];
       }
     }
-    if (options.embeds && options.embeds.length) {
+    if (options.embeds) {
       body.embeds = options.embeds.map((embed) => {
         if ('toJSON' in embed) {
           return embed;
@@ -3737,7 +3737,7 @@ export class Client extends EventSpewer {
         options.embeds = [];
       }
     }
-    if (options.embeds && options.embeds.length) {
+    if (options.embeds) {
       body.embeds = options.embeds.map((embed) => {
         if ('toJSON' in embed) {
           return embed;


### PR DESCRIPTION
You can remove messages on embeds by edited embeds to [], checking for length blocks this
I left this in on createMessage because embeds as [] doesn't change anything